### PR TITLE
Add achievements item to menu RV

### DIFF
--- a/app/src/main/java/com/example/android/alphap/MainActivity.java
+++ b/app/src/main/java/com/example/android/alphap/MainActivity.java
@@ -889,12 +889,19 @@ public class MainActivity extends AppCompatActivity
         ArrayList<Integer> mainRvImages = new ArrayList<>();
         mainRvImages.add(R.drawable.tractor_clip_art_470px);
         mainRvImages.add(R.drawable.barn_clipart_350px);
+        mainRvImages.add(R.drawable.tractor_clip_art_470px);
+
+        ArrayList<String> mainRvDescriptions = new ArrayList<>();
+        mainRvDescriptions.add("Create a new game of Tater Pop");
+        mainRvDescriptions.add("Check invitations or join a game");
+        mainRvDescriptions.add("View what you've unlocked");
 
         ArrayList<String> mainRvTvAList = new ArrayList<>();
         mainRvTvAList.add("Create");
         mainRvTvAList.add("Join");
+        mainRvTvAList.add("Achievements");
 
-        RecyclerView.Adapter adapter = new MainActivityRVAdapter(mainRvImages, mainRvTvAList, this);
+        RecyclerView.Adapter adapter = new MainActivityRVAdapter(mainRvImages, mainRvTvAList, mainRvDescriptions, this);
         recyclerView.setAdapter(adapter);
 
         ImageView signoutBtn = (ImageView) findViewById(R.id.signout_btn);
@@ -987,5 +994,10 @@ public class MainActivity extends AppCompatActivity
         Intent intent = Games.Invitations.getInvitationInboxIntent(mGoogleApiClient);
         switchToScreen(R.id.screen_wait);
         startActivityForResult(intent, RC_INVITATION_INBOX);
+    }
+
+    @Override
+    public void onAchievementsClicked() {
+        startActivityForResult(Games.Achievements.getAchievementsIntent(mGoogleApiClient), 0);
     }
 }

--- a/app/src/main/java/com/example/android/alphap/eddie/MainActivityRVAdapter.java
+++ b/app/src/main/java/com/example/android/alphap/eddie/MainActivityRVAdapter.java
@@ -1,6 +1,5 @@
 package com.example.android.alphap.eddie;
 
-import android.content.Context;
 import android.content.Intent;
 import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
@@ -16,12 +15,13 @@ import java.util.ArrayList;
 public class MainActivityRVAdapter extends RecyclerView.Adapter<MainActivityRVAdapter.ViewHolder> {
     private ArrayList<Integer> mainRvPics;
     private ArrayList<String> mainRvTv;
-    private Context context;
+    private ArrayList<String> mainRvDescriptions;
     private Listener listener;
 
-    public MainActivityRVAdapter(ArrayList<Integer> mainRvPics, ArrayList<String> mainRvTv, Listener listener) {
+    public MainActivityRVAdapter(ArrayList<Integer> mainRvPics, ArrayList<String> mainRvTv, ArrayList<String> mainRvDescriptions, Listener listener) {
         this.mainRvPics = mainRvPics;
         this.mainRvTv = mainRvTv;
+        this.mainRvDescriptions = mainRvDescriptions;
         this.listener = listener;
     }
 
@@ -34,27 +34,27 @@ public class MainActivityRVAdapter extends RecyclerView.Adapter<MainActivityRVAd
 
     @Override
     public void onBindViewHolder(MainActivityRVAdapter.ViewHolder viewHolder, int i) {
-
         viewHolder.mainRvIvPics.setImageResource(mainRvPics.get(i));
         viewHolder.mainRvTv.setText(mainRvTv.get(i));
-
+        viewHolder.mainRvDescription.setText(mainRvDescriptions.get(i));
     }
 
     @Override
     public int getItemCount() {
         return mainRvPics.size();
-
     }
 
     public class ViewHolder extends RecyclerView.ViewHolder {
         private ImageView mainRvIvPics;
         private TextView mainRvTv;
+        private TextView mainRvDescription;
 
         public ViewHolder(View view) {
             super(view);
 
             mainRvIvPics = (ImageView) view.findViewById(R.id.rv_image);
             mainRvTv = (TextView) view.findViewById(R.id.rv_tv);
+            mainRvDescription = (TextView) view.findViewById(R.id.rv_tv_description);
 
             mainRvIvPics.setOnClickListener(new View.OnClickListener() {
                 @Override
@@ -67,6 +67,9 @@ public class MainActivityRVAdapter extends RecyclerView.Adapter<MainActivityRVAd
                         case 1:
                             listener.onJoinGameClicked();
                             break;
+                        case 2:
+                            listener.onAchievementsClicked();
+                            break;
                     }
                 }
             });
@@ -77,5 +80,7 @@ public class MainActivityRVAdapter extends RecyclerView.Adapter<MainActivityRVAd
         void onCreateGameClicked();
 
         void onJoinGameClicked();
+
+        void onAchievementsClicked();
     }
 }


### PR DESCRIPTION
This PR adds a third item to the menu in MainActivity, "Achievements".

Clicking on the "Achievements" item takes the user to the default Google Play Games Services achievements view.

For now, we're using the tractor image (similar to the "Create" item). Eventually it would be nice to update this item to use it's own unique image.